### PR TITLE
Fix for thermostat card

### DIFF
--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -178,14 +178,28 @@ class VerticalStackInCard extends HTMLElement {
 
       .card-list-${this.id} {
         position: absolute;
-        top: -1000000px;
-        left: -1000000px;
+        width: 1px;
+        height: 1px;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        border: 0;
+        white-space: nowrap;
       }
 
       .card-list-${this.id}.is-toggled {
-        position: relative;
-        top: 0;
-        left: 0;
+        position: unset;
+        width: unset;
+        height: unset;
+        margin: unset;
+        padding: unset;
+        overflow: unset;
+        clip: unset;
+        clip-path: unset;
+        border: unset;
+        white-space: unset;
       }
 
       .toggle-button__icon-${this.id} {

--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -177,11 +177,15 @@ class VerticalStackInCard extends HTMLElement {
       }
 
       .card-list-${this.id} {
-        display: none;
+        position: absolute;
+        top: -1000000px;
+        left: -1000000px;
       }
 
       .card-list-${this.id}.is-toggled {
-        display: block;
+        position: relative;
+        top: 0;
+        left: 0;
       }
 
       .toggle-button__icon-${this.id} {


### PR DESCRIPTION
Fixes https://github.com/RossMcMillan92/lovelace-collapsable-cards/issues/14

I know it's a bit hacky, but it does work and I couldn't find anything else that would. The thermostat card uses `getBBox()`, and with `display: none`, it returns all zeros.