### PR TITLE
feat: add defaultOpen option to open if there are active entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Big thanks to [ofekashery, the author of vertical-stack-in-card](https://github.
 | ---------- | ------- | ------------ | ----------------------------------------- |
 | type       | string  |  | `custom:collapsable-cards`           |
 | cards      | list    |  | List of cards                         |
-| defaultOpen | string | false | Whether the cards should be visible by default. Can also be set to `desktop-only` to be open by default on desktop and collapsed by default on mobile. |
+| defaultOpen | string | false | Whether the cards should be visible by default. Can also be set to `desktop-only` to be open by default on desktop and collapsed by default on mobile. Or `contain-toggled` to open only if there are active entities |
 | title      | string  | "Toggle" | Dropdown title                       |
 | buttonStyle| string  | "" | CSS overrides for the dropdown toggle button |
 

--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -63,6 +63,14 @@ class VerticalStackInCard extends HTMLElement {
     const styleTag = document.createElement('style')
     styleTag.innerHTML = this.getStyles()
     card.appendChild(styleTag);
+
+    if (
+      config.defaultOpen === 'contain-toggled' && 
+      config.cards.filter((c) => this._hass.states[c.entity]?.state === "on")
+        .length > 0
+    ) {
+      toggleButton.click();
+    }
   }
 
   createToggleButton() {


### PR DESCRIPTION
on `defaultOpen: 'contain-toggled'` it will defaultly open the cards only if there are active entities