### PR TITLE
Fixed contain-toggled

### DIFF
--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -66,7 +66,7 @@ class VerticalStackInCard extends HTMLElement {
 
     if (
       config.defaultOpen === 'contain-toggled' && 
-      config.cards.filter((c) => this._hass.states[c.entity]?.state === "on")
+      config.cards.filter((c) => this._hass.states[c.entity]?.state !== "off")
         .length > 0
     ) {
       toggleButton.click();


### PR DESCRIPTION
Hi, condition for HA was in wrong direction. HA has multiple states representing some case of action aka `on`. For example `climate` can have `heating`, `cooling`, ... or in my case `media_player` have `playing`. The `off` state is universal thru all components. So I switch that. We can consider if there should be `idle` state too(again `climate` component) which means it's "on" but nothing to do.