### PR TITLE
Add title_card option

### DIFF
--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -25,6 +25,7 @@ class VerticalStackInCard extends HTMLElement {
 
     this._config = config;
     this._refCards = [];
+    this._titleCard = null;
     this.renderCard();
   }
 
@@ -35,6 +36,10 @@ class VerticalStackInCard extends HTMLElement {
     }
     const promises = config.cards.map((config) => this.createCardElement(config));
     this._refCards = await Promise.all(promises);
+
+    if (config.title_card) {
+      this._titleCard = await this.createCardElement(config.title_card);
+    }
 
     // Create the card
     const card = document.createElement('ha-card');
@@ -78,7 +83,11 @@ class VerticalStackInCard extends HTMLElement {
 
   createToggleButton() {
     const toggleButton = document.createElement('button');
-    toggleButton.innerHTML = this._config.title || 'Toggle'
+    if (this._titleCard) {
+      toggleButton.append(this._titleCard);
+    } else {
+      toggleButton.innerHTML = this._config.title || 'Toggle';
+    }
     toggleButton.className = 'card-content toggle-button-' + this.id
     toggleButton.addEventListener('click', () => {
       this.isToggled = !this.isToggled
@@ -157,6 +166,9 @@ class VerticalStackInCard extends HTMLElement {
       this._refCards.forEach((card) => {
         card.hass = hass;
       });
+    }
+    if (this._titleCard) {
+      this._titleCard.hass = hass;
     }
   }
 


### PR DESCRIPTION
New option `title_card` which allows to add more complex titles.

Example with Mushroom chips card:
```yaml
type: custom:collapsable-cards
style: |
  ha-card, ha-card button:focus {
    background: none !important;
    box-shadow: none;
  }
  ha-card button {
    padding: 6px;
  }
title_card:
  type: custom:mushroom-chips-card
  chips:
    - type: entity
      entity: sensor.ble_temperature
      icon_color: yellow
    - type: entity
      entity: sensor.ble_humidity
      icon_color: blue
    - type: entity
      entity: sensor.ble_battery
      icon_color: red
cards:
  - type: custom:mini-graph-card
    show:
      name: false
      icon: false
    entities:
      - entity: sensor.ble_temperature
        name: temperatura
      - entity: sensor.ble_humidity
        name: wilgotność
        y_axis: secondary
        show_state: true
```

Closed card:
![image](https://user-images.githubusercontent.com/4903046/201501096-2d6d35e0-4a1a-465f-9a64-662dbf3daea2.png)

Opened card:
![image](https://user-images.githubusercontent.com/4903046/201501100-54db5dac-2b1c-4b9e-9b00-3af9102be17c.png)



