### PR TITLE
Refactor to ha-expansion-panel.

### DIFF
--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -45,7 +45,6 @@ class CollapsableCards extends HTMLElement {
 		// Create the card
 		const card = document.createElement('ha-expansion-panel');
 		this.card = card;
-		card.style.setProperty('--expansion-panel-content-padding', '0px')
 		card.setAttribute('header', this._titleCard || this._config.title || 'Toggle');
 		card.setAttribute('outlined', '');
 		const cardList = document.createElement('div');
@@ -57,6 +56,7 @@ class CollapsableCards extends HTMLElement {
 		}
 		this.injectStyles(card, this.getStyles());
 		card.appendChild(cardList);
+		this.injectStyles(this, 'ha-expansion-panel { --expansion-panel-content-padding: 0px }')
 		this.appendChild(card);
 
 		// Calculate card size

--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -43,21 +43,16 @@ class CollapsableCards extends HTMLElement {
 		}
 
 		// Create the card
-		const card = document.createElement('ha-card');
-		this.card = card
+		const card = document.createElement('ha-expansion-panel');
+		this.card = card;
+		card.setAttribute('header', this._titleCard || this._config.title || 'Toggle');
+		card.setAttribute('outlined', '');
 		const cardList = document.createElement('div');
-		this.cardList = cardList
-		card.style.overflow = 'hidden';
+		cardList.id = 'root';
+		this.cardList = cardList;
 		this._refCards.forEach((card) => cardList.appendChild(card));
-		this.cardList.className = 'card-list-' + this.id
-		this.cardList.classList[this.isToggled ? 'add' : 'remove']('is-toggled')
 
-		// create the button
-		const toggleButton = this.createToggleButton()
-
-		card.appendChild(toggleButton);
 		card.appendChild(cardList);
-
 		while (this.hasChildNodes()) {
 			this.removeChild(this.lastChild);
 		}
@@ -70,9 +65,9 @@ class CollapsableCards extends HTMLElement {
 		styleTag.innerHTML = this.getStyles()
 		card.appendChild(styleTag);
 
-		if (config.defaultOpen === 'contain-toggled') {
-			this.toggle(this.isCardActive());
-		}
+		this.isToggled = config.defaultOpen === 'contain-toggled' ? this.isCardActive() : this.isToggled;
+
+		if (this.isToggled) card.setAttribute('expanded', '');
 	}
 
 	getEntitiesNames(card) {
@@ -92,38 +87,6 @@ class CollapsableCards extends HTMLElement {
 
 	isCardActive() {
 		return this.getEntitiesNames(this._config).filter((e) => this._hass.states[e].state !== "off").length > 0
-	}
-
-	toggle(open = null) {
-		this.isToggled = open === null ? !this.isToggled : open;
-		this.styleCard(this.isToggled);
-	}
-
-	createToggleButton() {
-		const toggleButton = document.createElement('button');
-		if (this._titleCard) {
-			toggleButton.append(this._titleCard);
-		} else {
-			toggleButton.innerHTML = this._config.title || 'Toggle';
-		}
-		toggleButton.className = 'card-content toggle-button-' + this.id
-		toggleButton.addEventListener('click', () => {
-			this.isToggled = !this.isToggled
-			this.styleCard(this.isToggled)
-		})
-
-		const icon = document.createElement('ha-icon');
-		icon.className = 'toggle-button__icon-' + this.id
-		icon.setAttribute('icon', 'mdi:chevron-down')
-		this.icon = icon
-		toggleButton.appendChild(icon)
-
-		return toggleButton
-	}
-
-	styleCard(isToggled) {
-		this.cardList.classList[isToggled ? 'add' : 'remove']('is-toggled')
-		this.icon.setAttribute('icon', isToggled ? 'mdi:chevron-up' : 'mdi:chevron-down')
 	}
 
 	async createCardElement(cardConfig) {
@@ -226,58 +189,10 @@ class CollapsableCards extends HTMLElement {
 
 	getStyles() {
 		return `
-      .toggle-button-${this.id} {
-        color: var(--primary-text-color);
-        text-align: left;
-        background: none;
-        border: none;
-        margin: 0;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-        border-radius: var(--ha-card-border-radius, 4px);
-        ${this._config.buttonStyle || ''}
-      }
-      .toggle-button-${this.id}:focus {
-        outline: none;
-        background-color: var(--divider-color);
-      }
-
-      .card-list-${this.id} {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-        clip: rect(0 0 0 0);
-        clip-path: inset(50%);
-        border: 0;
-        white-space: nowrap;
-      }
-
-      .card-list-${this.id}.is-toggled {
-        position: unset;
-        width: unset;
-        height: unset;
-        margin: unset;
-        padding: unset;
-        overflow: unset;
-        clip: unset;
-        clip-path: unset;
-        border: unset;
-        white-space: unset;
-      }
-
-      .toggle-button__icon-${this.id} {
-        color: var(--paper-item-icon-color, #aaa);
-      }
-
-      .type-custom-collapsable-cards {
-        background: transparent;
-      }
-    `;
+        #root {
+          margin: 0 -8px;
+        }
+      `;
 	}
 
 }

--- a/collapsable-cards.js
+++ b/collapsable-cards.js
@@ -45,25 +45,22 @@ class CollapsableCards extends HTMLElement {
 		// Create the card
 		const card = document.createElement('ha-expansion-panel');
 		this.card = card;
+		card.style.setProperty('--expansion-panel-content-padding', '0px')
 		card.setAttribute('header', this._titleCard || this._config.title || 'Toggle');
 		card.setAttribute('outlined', '');
 		const cardList = document.createElement('div');
-		cardList.id = 'root';
-		this.cardList = cardList;
-		this._refCards.forEach((card) => cardList.appendChild(card));
+		cardList.id = "root";
+		this._refCards.forEach((c) => cardList.appendChild(c));
 
-		card.appendChild(cardList);
 		while (this.hasChildNodes()) {
 			this.removeChild(this.lastChild);
 		}
+		this.injectStyles(card, this.getStyles());
+		card.appendChild(cardList);
 		this.appendChild(card);
 
 		// Calculate card size
 		this._cardSize.resolve();
-
-		const styleTag = document.createElement('style')
-		styleTag.innerHTML = this.getStyles()
-		card.appendChild(styleTag);
 
 		this.isToggled = config.defaultOpen === 'contain-toggled' ? this.isCardActive() : this.isToggled;
 
@@ -187,12 +184,29 @@ class CollapsableCards extends HTMLElement {
 		return sizes.reduce((a, b) => a + b);
 	}
 
+	injectStyles(element, css) {
+		const styleTag = document.createElement('style')
+		styleTag.innerHTML = css
+		element.appendChild(styleTag);
+	}
+
 	getStyles() {
 		return `
-        #root {
-          margin: 0 -8px;
+		#root {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+        } 
+		#root > * {
+          margin: var(
+            --vertical-stack-card-margin,
+            var(--stack-card-margin, 4px 0)
+          );
         }
-      `;
+        #root > *:last-child {
+          margin-bottom: 0;
+        }
+		`
 	}
 
 }


### PR DESCRIPTION
So, let's get started.

This PR change custom collabsable element to HA native component named `ha-expansion-panel`. It reduce core logic for toggling, styling icons etc. Even we can easily add sub-title if it's wanted (just add config text option and set it as attributte `secondary` for `ha-expansion-panel` DOM in same way like `header` attr for title) this is 5 minutes job.

By this PR we get more clearer code and get rid of logic which don't have to be maintained. We don't have to creeping with styles to get HA design guidelines and that is great if they will be changed in time - HA is now updating styles to respect Material 3 design guidelines.

I'm not saying there cannot be done some little tweaking with styles to get it nicer (it's point of view, I like it as it it's). But this solving @ScottG489's and @andrzejl's problems from #28. `title_card` is almost fully expanded by default. I even tested setup with `horizontal-stack` card with 3 more inner cards and it looks and work good, **but** when you add fourth it overflows. There's only one bigger **BUT**. Old version propagate clicks from `title_card` to parent so it open `title_card` detail and call toggle in same time. My modification don't do this and I don't know what is wanted behavioral.

Show time
--------------
```yaml
type: custom:collapsable-cards
title: Audio/Video
title_card:
  type: horizontal-stack
  cards:
    - type: tile
      entity: sensor.bedroom_temperature
#    - type: tile
#      entity: sensor.bedroom_temperature
#    - type: tile
#      entity: sensor.bedroom_temperature
cards:
  - type: grid
    columns: 1
    square: false
    cards:
      - type: vertical-stack
        cards:
          - type: tile
            entity: media_player.tomas_shieldtv
            color: blue
defaultOpen: contain-toggled
show_header_toggle: true
```
![Snímek obrazovky z 2022-11-16 13-13-02](https://user-images.githubusercontent.com/5030499/202183587-23b8ecc8-59f1-4c45-9466-ebe7ba064bb3.png)
![Snímek obrazovky z 2022-11-16 13-47-03](https://user-images.githubusercontent.com/5030499/202184581-01e420fa-c937-4d59-bd99-fc55856380f0.png)

OR More !!!
![Snímek obrazovky z 2022-11-16 13-44-32](https://user-images.githubusercontent.com/5030499/202184080-7609d069-005c-477d-a957-970e7e960265.png)
And collapsed
![Snímek obrazovky z 2022-11-16 13-12-24](https://user-images.githubusercontent.com/5030499/202183759-6812c703-4022-4609-b11b-95f6b63ae532.png)
![Snímek obrazovky z 2022-11-16 13-46-48](https://user-images.githubusercontent.com/5030499/202184764-b682ac3f-d224-4252-a19c-fa2749d790f6.png)

Sources
-----------
In HA you can open from sidebar _Developers tools -> States_ and there is this component used.

Source code of component is [HERE](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-expansion-panel.ts). Source code of states page with usage example is [HERE](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/state/developer-tools-state.js)

Conclusion
---------------
@RossMcMillan92 even all works like in nice and pinky world, this change is BC break for user's custom styles and script. I have to suggest you publish this as beta first and @andrzejl can test, if it respect his idea about `title_card`.

Thank you for your attention!
